### PR TITLE
fix(LoanApplication.cs) param mixup

### DIFF
--- a/LoanApplication.DomainTests/When_updating_a_loan_application_when_missing_required_values.cs
+++ b/LoanApplication.DomainTests/When_updating_a_loan_application_when_missing_required_values.cs
@@ -30,7 +30,7 @@
         [Fact]
         public void When_adress_is_missing_null_exception_is_thrown()
         {
-            Assert.Throws<ArgumentNullException>(() => _loanApplication.UpdateLoanApplication("Pepe", "Silva", null, "14628", "Silent Third Harbor", 100000, 18, 33000, 0));
+            Assert.Throws<ArgumentNullException>("adress", () => _loanApplication.UpdateLoanApplication("Pepe", "Silva", null, "14628", "Silent Third Harbor", 100000, 18, 33000, 0));
         }
 
         [Fact]

--- a/LoanApplicationApi/Domain/LoanApplication.cs
+++ b/LoanApplicationApi/Domain/LoanApplication.cs
@@ -29,8 +29,8 @@ namespace LoanApplicationAPI.Domain
 
         public LoanApplication(
             string firstName,
-            string lastname, 
-            string adress, 
+            string lastname,
+            string adress,
             string zip,
             string street,
             decimal loanAmount,
@@ -66,7 +66,7 @@ namespace LoanApplicationAPI.Domain
         {
             _state.FirstName = firstName ?? throw new ArgumentNullException(nameof(firstName));
             _state.LastName = lastname ?? throw new ArgumentNullException(nameof(lastname));
-            _state.Adress = adress ?? throw new ArgumentNullException(nameof(zip));
+            _state.Adress = adress ?? throw new ArgumentNullException(nameof(adress));
             _state.Zip = zip ?? throw new ArgumentNullException(nameof(zip));
             _state.Street = street ?? throw new ArgumentNullException(nameof(street));
             _state.LoanAmount = loanAmount;


### PR DESCRIPTION
when adress was missing, zip was used
as parameter name, should have been adress.